### PR TITLE
Pagination of API searches

### DIFF
--- a/plugins/europeana/search.js
+++ b/plugins/europeana/search.js
@@ -145,17 +145,22 @@ function facetsFromApiResponse(response) {
 /**
  * Search Europeana Record API
  * @param {Object} params parameters for search query
+ * @param {number} params.page page of results to retrieve
  * @param {string} params.query search query
  * @param {string} params.wskey API key
  * @return {{results: Object[], totalResults: number, facets: FacetSet, error: string}} search results for display
  */
 function search(params) {
+  const perPage = 24;
+  const page = params.page || 1;
+
   return axios.get('https://api.europeana.eu/api/v2/search.json', {
     params: {
       profile: 'minimal,facets',
       facet: 'TYPE',
       query: params.query == '' ? '*:*' : params.query,
-      rows: 24,
+      rows: perPage,
+      start: ((page - 1) * perPage) + 1,
       wskey: params.wskey
     }
   })

--- a/tests/unit/plugins/europeana/record.spec.js
+++ b/tests/unit/plugins/europeana/record.spec.js
@@ -10,6 +10,10 @@ const apiEndpoint = `/api/v2/record${europeanaId}.json`;
 const apiKey = 'abcdef';
 
 describe('plugins/europeana/record', () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
   describe('getRecord()', () => {
 
     describe('when trying to request an unknown record', () => {

--- a/tests/unit/plugins/europeana/search.spec.js
+++ b/tests/unit/plugins/europeana/search.spec.js
@@ -12,6 +12,10 @@ const baseRequest = nock(apiUrl).get(apiEndpoint);
 const defaultResponse = { success: true, items: [], totalResults: 123456 };
 
 describe('plugins/europeana/search', () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
   describe('search()', () => {
     describe('API request', () => {
       it('includes API key', async () => {
@@ -34,6 +38,18 @@ describe('plugins/europeana/search', () => {
           .reply(200, defaultResponse);
 
         await search({ query: 'anything', wskey: apiKey });
+
+        nock.isDone().should.be.true;
+      });
+
+      it('paginates if `page` is passed', async () => {
+        baseRequest
+          .query(query => {
+            return query.rows === '24' && query.start === '25';
+          })
+          .reply(200, defaultResponse);
+
+        await search({ page: 2, query: 'anything', wskey: apiKey });
 
         nock.isDone().should.be.true;
       });


### PR DESCRIPTION
`afterEach` hook added to plugin unit tests are to prevent a single failing test with unused nock stubs causing many others to appear to fail.