### PR TITLE
Use expect syntax

### DIFF
--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -40,7 +40,9 @@ defineStep(/^I should be on.*? `(.*)`$/, pageName => {
   } else {
     expectedUrl = pages[pageName];
   }
-  // TODO: Update the assert below with expect syntax, if there's a clean way to do so.
+  // TODO: update if a less verbose syntax becomes available.
   // See https://github.com/nightwatchjs/nightwatch/issues/861
-  client.assert.urlEquals(expectedUrl);
+  client.url(currentUrl => {
+    client.expect(currentUrl.value).to.eq(expectedUrl);
+  });
 });


### PR DESCRIPTION
Favour using the expect syntax which leads to the tests being consistent.

Assert seems to sometimes run outside of it's step and into the next scenario, meaning it causes flickering tests as it interferes with the loading of the next scenario.