### PR TITLE
Update e2e test syntax

### DIFF
--- a/tests/features/browse-page.feature
+++ b/tests/features/browse-page.feature
@@ -4,5 +4,4 @@ Feature: Browse page
 
     When I open the `home page`
     Then I see the `title`
-    And I see a `browse section`
     And I see a `content card` in the `browse section`

--- a/tests/features/header.feature
+++ b/tests/features/header.feature
@@ -3,30 +3,27 @@ Feature: Page Header
   Scenario: Seeing the header everywhere
 
     When I open the `home page`
-    Then I see the `header`
-    And I see the `logo` in the `header`
+    Then I see the `logo` in the `header`
     And I see the `search box` in the `header`
 
     When I open the `search page`
-    Then I see the `header`
-    And I see the `logo` in the `header`
+    Then I see the `logo` in the `header`
     And I see the `search box` in the `header`
 
     When I open a `record page`
-    Then I see the `header`
-    And I see the `logo` in the `header`
+    Then I see the `logo` in the `header`
     And I see the `search box` in the `header`
 
   Scenario: Using the logo to get back to the homepage
 
-    Given I open a `record page`
-    And I see the `header`
-    And I see the `logo` in the `header`
-    When I click on the  `logo` in the `header`
+    When I open a `record page`
+    And I click on the  `logo` in the `header`
     Then I should be on the `home page`
 
-    Given I open the `search page`
-    And I see the `header`
-    And I see the `logo` in the `header`
-    When I click on the `logo` in the `header`
+    When I open the `search page`
+    And I click on the `logo` in the `header`
+    Then I should be on the `home page`
+
+    When I open the `home page`
+    And I click on the `logo` in the `header`
     Then I should be on the `home page`

--- a/tests/features/record-page.feature
+++ b/tests/features/record-page.feature
@@ -5,7 +5,6 @@ Feature: Record page
     When I open a `record page`
     Then I see the `record page`
     And I see a `metadata field`
-    And I see a `web resource`
     And I see a `metadata field` in the `web resource`
 
   Scenario: Attempting to view a record page which doesn't exist

--- a/tests/features/search/faceting.feature
+++ b/tests/features/search/faceting.feature
@@ -5,7 +5,7 @@ Feature: Search faceting
     When I visit the `search page`
     And I enter "" in the `search box`
     And I click the `search button`
-    Then I see a `search facet` with text "Type of media"
+    Then I see a `search facet` with the text "Type of media"
 
   Scenario: Filtering results by types
 
@@ -13,4 +13,4 @@ Feature: Search faceting
     And I check the "IMAGE" checkbox
     And I wait 1 second
     Then I should be on `/search?query=&page=1&qf=TYPE%3AIMAGE`
-    And I see a `filter badge` with text "Type of media: IMAGE"
+    And I see a `filter badge` with the text "Type of media: IMAGE"

--- a/tests/features/search/pagination.feature
+++ b/tests/features/search/pagination.feature
@@ -13,16 +13,16 @@ Feature: Search pagination
     Then I should be on the `first page of results`
 
     When I open `/search?query=&page=0`
-    Then I should be on `first page of results`
+    Then I should be on the `first page of results`
 
     When I open `/search?query=&page=one`
-    Then I should be on `first page of results`
+    Then I should be on the `first page of results`
 
     When I open `/search?query=&page=last`
-    Then I should be on `first page of results`
+    Then I should be on the `first page of results`
 
     When I open `/search?query=&page=2.5`
-    Then I should be on `first page of results`
+    Then I should be on the `first page of results`
 
   Scenario: Paginating beyond API result limit
 

--- a/tests/features/search/pagination.feature
+++ b/tests/features/search/pagination.feature
@@ -2,35 +2,35 @@ Feature: Search pagination
 
   Scenario: Pagination of search results
 
-    Given I visit the `search page`
-    When I enter "" in the `search box`
+    When I visit the `search page`
+    And I enter "" in the `search box`
     And I click the `search button`
     Then I see a `pagination navigation`
 
   Scenario: Invalid `page` param redirects to page 1
 
     When I open `/search?query=&page=-1`
-    Then I should be on `/search?query=&page=1`
+    Then I should be on the `first page of results`
 
     When I open `/search?query=&page=0`
-    Then I should be on `/search?query=&page=1`
+    Then I should be on `first page of results`
 
     When I open `/search?query=&page=one`
-    Then I should be on `/search?query=&page=1`
+    Then I should be on `first page of results`
 
     When I open `/search?query=&page=last`
-    Then I should be on `/search?query=&page=1`
+    Then I should be on `first page of results`
 
     When I open `/search?query=&page=2.5`
-    Then I should be on `/search?query=&page=1`
+    Then I should be on `first page of results`
 
   Scenario: Paginating beyond API result limit
 
     When I open `/search?query=&page=500`
-    Then I see an `error notice` with text "It is only possible to view the first 1000 search results."
+    Then I see an `error notice` with the text "It is only possible to view the first 1000 search results."
 
   Scenario: Paginating beyond available results
 
     When I open `/search?query=title%3Amilkmaid&page=10`
-    Then I see a `warning notice` with text "no more results"
+    Then I see a `warning notice` with the text "no more results"
     And I see a `pagination navigation`

--- a/tests/features/search/querying.feature
+++ b/tests/features/search/querying.feature
@@ -2,32 +2,31 @@ Feature: Search querying
 
   Scenario: Search existing Europeana content
 
-    Given I visit a `search page`
-    When I enter "paris" in the `search box`
+    When I visit a `search page`
+    And I enter "paris" in the `search box`
     And I click the `search button`
     Then I see a `search result`
     And I see the `total results`
 
   Scenario: Search non existing Europeana content
 
-    Given I visit a `search page`
-    When I enter "no results for GIBBERISHABCDEFGHIJKLMONP" in the `search box`
+    When I visit a `search page`
+    And I enter "no results for GIBBERISHABCDEFGHIJKLMONP" in the `search box`
     And I click the `search button`
     Then I don't see a `search result`
 
   Scenario: Search with invalid query syntax
 
-    Given I visit a `search page`
-    When I enter "*:*:*" in the `search box`
+    When I visit a `search page`
+    And I enter "*:*:*" in the `search box`
     And I click the `search button`
     Then I don't see a `search result`
-    And I see an `error notice`
+    And I see an `error notice` with the text "Error: Invalid query parameter."
 
   Scenario: Search and navigate to record
 
-    Given I visit a `search page`
-    When I enter "paris" in the `search box`
+    When I visit a `search page`
+    And I enter "paris" in the `search box`
     And I click the `search button`
-    And I see a `search result`
     And I click a `search result`
     Then I see a `record page`

--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -15,7 +15,8 @@ const { url } = require('../config/nightwatch.conf.js').test_settings.default.gl
 const pages = {
   'home page': `${url}/`,
   'search page': `${url}/search`,
-  'record page': `${url}/record${europeanaId()}`
+  'record page': `${url}/record${europeanaId()}`,
+  'first page of results': `${url}/search?query=&page=1`
 };
 
 defineStep(/^I (?:browse|open|visit).*? `(.*?)`$/, pageName => {
@@ -29,7 +30,7 @@ defineStep(/^I (?:browse|open|visit).*? `(.*?)`$/, pageName => {
 defineStep(/^I (?:find|identify|see|spot).*? (`.*`)$/, selectorChain =>
   client.expect.element(nestedSelector(selectorChain)).to.be.visible);
 
-defineStep(/^I (?:find|identify|see|spot).*? (`.*`) with text "(.*)"$/, (selectorChain, value) =>
+defineStep(/^I (?:find|identify|see|spot).*? (`.*`) with the text "(.*)"$/, (selectorChain, value) =>
   client.expect.element(nestedSelector(selectorChain)).text.to.contain(value));
 
 defineStep(/^I (?:can|don)'t (?:find|identify|see|spot).*? (`.*`).*?$/, selectorChain =>
@@ -39,11 +40,15 @@ defineStep(/^I (?:wait|pause) (\d+) seconds?$/, async (waitSeconds) => {
   await client.pause(waitSeconds * 1000);
 });
 
-defineStep(/^I (?:enter|fill|input|supply|type).*? "(.*?)" in.*? (`.*`)$/, (value, selectorChain) =>
-  client.setValue(nestedSelector(selectorChain), value));
+defineStep(/^I (?:enter|fill|input|supply|type).*? "(.*?)" in.*? (`.*`)$/, async (value, selectorChain) => {
+  await client.expect.element(nestedSelector(selectorChain)).to.be.visible;
+  await client.setValue(nestedSelector(selectorChain), value);
+});
 
-defineStep(/^I (?:activate|click).*? (`.*`)$/, selectorChain =>
-  client.click(nestedSelector(selectorChain)));
+defineStep(/^I (?:activate|click).*? (`.*`)$/, async(selectorChain) => {
+  await client.expect.element(nestedSelector(selectorChain)).to.be.visible;
+  await client.click(nestedSelector(selectorChain));
+});
 
 defineStep(/^I (?:check|click).*? "(.*)" checkbox$/, inputValue =>
   client.click(`input[type="checkbox"][value="${inputValue}"]`));


### PR DESCRIPTION
* Await element presence before 'filling in' and click interactions, so that we don't need to explicitly test for these in the scenarios. (+removed all checks like this from scenarios)
* Visiting pages is a 'When' not a 'Given'
* Update language for the check that confirms presence of text in an element. (added 'the')
* Added a human readable getter for 'first page of results'