### PR TITLE
Pagination refinements

### DIFF
--- a/components/generic/InfoMessage.stories.js
+++ b/components/generic/InfoMessage.stories.js
@@ -1,0 +1,15 @@
+import { storiesOf } from '@storybook/vue';
+
+import InfoMessage from './InfoMessage.vue';
+
+storiesOf('Generic', module)
+.add('Info message', () => ({
+components: { InfoMessage },
+template: ` <b-container
+  class="mt-3"
+>
+  <InfoMessage
+    message="This section only exists to inform you of something."
+  />
+</b-container>`
+}));

--- a/components/generic/InfoMessage.stories.js
+++ b/components/generic/InfoMessage.stories.js
@@ -3,13 +3,13 @@ import { storiesOf } from '@storybook/vue';
 import InfoMessage from './InfoMessage.vue';
 
 storiesOf('Generic', module)
-.add('Info message', () => ({
-components: { InfoMessage },
-template: ` <b-container
-  class="mt-3"
->
-  <InfoMessage
-    message="This section only exists to inform you of something."
-  />
-</b-container>`
-}));
+  .add('Info message', () => ({
+    components: { InfoMessage },
+    template: ` <b-container
+      class="mt-3"
+      >
+        <InfoMessage
+          message="This section only exists to inform you of something."
+        />
+      </b-container>`
+  }));

--- a/components/generic/InfoMessage.vue
+++ b/components/generic/InfoMessage.vue
@@ -1,0 +1,20 @@
+<template>
+  <b-alert
+    show
+    variant="light"
+    data-qa="info notice"
+  >
+    <i>{{ message }}</i>
+  </b-alert>
+</template>
+
+<script>
+  export default {
+    props: {
+      message: {
+        type: String,
+        default: ''
+      }
+    }
+  };
+</script>

--- a/components/generic/InfoMessage.vue
+++ b/components/generic/InfoMessage.vue
@@ -4,7 +4,7 @@
     variant="light"
     data-qa="info notice"
   >
-    <i>{{ message }}</i>
+    {{ message }}
   </b-alert>
 </template>
 
@@ -18,3 +18,9 @@
     }
   };
 </script>
+
+<style lang="scss">
+  .alert.alert-light {
+    font-style: italic;
+  }
+</style>

--- a/components/generic/PaginationNav.vue
+++ b/components/generic/PaginationNav.vue
@@ -51,7 +51,7 @@
     },
     computed: {
       totalPages: function () {
-        return Math.ceil(Math.min(this.totalResults, maxResults) / this.perPage);
+        return Math.ceil(Math.min(Math.max(this.totalResults, 1), maxResults) / this.perPage);
       }
     },
     watch: {

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -38,7 +38,7 @@
       </b-col>
     </b-row>
     <b-row
-      v-if="totalResults !== null"
+      v-if="hasResults"
       class="mb-3"
     >
       <b-col>
@@ -65,7 +65,7 @@
         lg="9"
       >
         <template
-          v-if="results !== null"
+          v-if="hasResults"
         >
           <b-row>
             <b-col>
@@ -234,6 +234,11 @@
         }
         this.isLoading = true;
         this.$router.push({ name: 'search', query: { query: this.query || '', page: '1', qf: this.qfForSelectedFacets } });
+      }
+    },
+    computed: {
+      hasResults: function() {
+        return this.results !== null && this.totalResults > 0;
       }
     },
     head () {

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -153,7 +153,8 @@
         query: null,
         page: 1,
         facets: {},
-        selectedFacets: {}
+        selectedFacets: {},
+        qfForSelectedFacets: []
       };
     },
     asyncData ({ env, query, res, redirect }) {

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -204,6 +204,11 @@
           return { results: null, error: errorMessage, query: query.query };
         });
     },
+    computed: {
+      hasResults: function() {
+        return this.results !== null && this.totalResults > 0;
+      }
+    },
     mounted () {
       this.$nextTick(() => {
         if (document.getElementById('searchResults') === null) {
@@ -236,11 +241,6 @@
         }
         this.isLoading = true;
         this.$router.push({ name: 'search', query: { query: this.query || '', page: '1', qf: this.qfForSelectedFacets } });
-      }
-    },
-    computed: {
-      hasResults: function() {
-        return this.results !== null && this.totalResults > 0;
       }
     },
     head () {

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -181,7 +181,7 @@
             query: query.query,
             page: Number(currentPage),
             selectedFacets: selectedFacetsFromQueryQf(query.qf),
-            qfForSelectedFacets: query.qf
+            qfForSelectedFacets: query.qf === '' ? [] : query.qf
           };
         })
         .catch((error) => {

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -93,7 +93,7 @@
                 :results="results"
               />
               <InfoMessage
-                v-if="this.lastAvailablePage"
+                v-if="lastAvailablePage"
                 message="Additional results are not shown as only the first 1000 most relevant results are shown. If you haven't found what you're looking for, please consider refining your search."
               />
             </b-col>
@@ -157,6 +157,11 @@
         qfForSelectedFacets: []
       };
     },
+    computed: {
+      hasResults: function() {
+        return this.results !== null && this.totalResults > 0;
+      }
+    },
     asyncData ({ env, query, res, redirect }) {
       const currentPage = pageFromQuery(query.page);
       if (currentPage === null) {
@@ -203,11 +208,6 @@
           // TODO: include selectedFacets?
           return { results: null, error: errorMessage, query: query.query };
         });
-    },
-    computed: {
-      hasResults: function() {
-        return this.results !== null && this.totalResults > 0;
-      }
     },
     mounted () {
       this.$nextTick(() => {

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -92,6 +92,10 @@
                 v-else
                 :results="results"
               />
+              <InfoMessage
+                v-if="this.lastAvailablePage"
+                message="Additional results are not shown as only the first 1000 most relevant results are shown. If you haven't found what you're looking for, please consider refining your search."
+              />
             </b-col>
           </b-row>
           <b-row>
@@ -113,6 +117,7 @@
 
 <script>
   import AlertMessage from '../../components/generic/AlertMessage';
+  import InfoMessage from '../../components/generic/InfoMessage';
   import SearchFacet from '../../components/search/SearchFacet';
   import SearchForm from '../../components/search/SearchForm';
   import SearchResultsList from '../../components/search/SearchResultsList';
@@ -123,6 +128,7 @@
   export default {
     components: {
       AlertMessage,
+      InfoMessage,
       SearchFacet,
       SearchForm,
       SearchResultsList,
@@ -143,6 +149,7 @@
         inHeader: false,
         results: null,
         totalResults: null,
+        lastAvailablePage: false,
         query: null,
         page: 1,
         facets: {},

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -180,7 +180,8 @@
             isLoading: false,
             query: query.query,
             page: Number(currentPage),
-            selectedFacets: selectedFacetsFromQueryQf(query.qf)
+            selectedFacets: selectedFacetsFromQueryQf(query.qf),
+            qfForSelectedFacets: query.qf
           };
         })
         .catch((error) => {

--- a/plugins/europeana/search.js
+++ b/plugins/europeana/search.js
@@ -235,7 +235,8 @@ function search(params) {
         error: null,
         results: resultsFromApiResponse(response),
         facets: facetsFromApiResponse(response),
-        totalResults: response.data.totalResults
+        totalResults: response.data.totalResults,
+        lastAvailablePage: start + perPage > maxResults
       };
     })
     .catch((error) => {

--- a/tests/features/search/pagination.feature
+++ b/tests/features/search/pagination.feature
@@ -7,6 +7,31 @@ Feature: Search pagination
     And I click the `search button`
     Then I see a `pagination navigation`
 
+  Scenario: Pagination links preserve query and facet selection.
+
+    When I visit the `home page`
+    And I enter "paris" in the `search box`
+    And I click the `search button`
+    And I wait for a `search result`
+    And I check the "IMAGE" checkbox
+    And I wait 1 second
+    Then I see a link to "/search?query=paris&page=2&qf=TYPE%3AIMAGE" in the `pagination navigation`
+
+  Scenario: Pagination links preserve query and facet selection from the blank search page.
+
+    When I visit the `search page`
+    And I enter "paris" in the `search box`
+    And I click the `search button`
+    And I wait for a `search result`
+    And I check the "IMAGE" checkbox
+    And I wait 5 seconds
+    Then I see a link to "/search?query=paris&page=2&qf=TYPE%3AIMAGE" in the `pagination navigation`
+
+  Scenario: Pagination links preserve query and facet selection from the url.
+
+    When I visit the `/search?query=paris&page=1&qf=TYPE%3AIMAGE`
+    Then I see a link to "/search?query=paris&page=2&qf=TYPE%3AIMAGE" in the `pagination navigation`
+
   Scenario: Invalid `page` param redirects to page 1
 
     When I open `/search?query=&page=-1`

--- a/tests/features/search/pagination.feature
+++ b/tests/features/search/pagination.feature
@@ -24,7 +24,7 @@ Feature: Search pagination
     And I click the `search button`
     And I wait for a `search result`
     And I check the "IMAGE" checkbox
-    And I wait 5 seconds
+    And I wait 1 seconds
     Then I see a link to "/search?query=paris&page=2&qf=TYPE%3AIMAGE" in the `pagination navigation`
 
   Scenario: Pagination links preserve query and facet selection from the url.

--- a/tests/features/search/pagination.feature
+++ b/tests/features/search/pagination.feature
@@ -28,7 +28,7 @@ Feature: Search pagination
 
     When I open `/search?query=&page=42`
     Then I see a `search result`
-    Then I see an `info notice` with text "Additional results are not shown as only the first 1000 most relevant results are shown. If you haven't found what you're looking for, please consider refining your search."
+    Then I see an `info notice` with the text "Additional results are not shown as only the first 1000 most relevant results are shown. If you haven't found what you're looking for, please consider refining your search."
 
   Scenario: Paginating beyond API result limit
 

--- a/tests/features/search/pagination.feature
+++ b/tests/features/search/pagination.feature
@@ -24,6 +24,12 @@ Feature: Search pagination
     When I open `/search?query=&page=2.5`
     Then I should be on `/search?query=&page=1`
 
+  Scenario: Paginating to the API result limit
+
+    When I open `/search?query=&page=42`
+    Then I see a `search result`
+    Then I see an `info notice` with text "Additional results are not shown as only the first 1000 most relevant results are shown. If you haven't found what you're looking for, please consider refining your search."
+
   Scenario: Paginating beyond API result limit
 
     When I open `/search?query=&page=500`

--- a/tests/features/search/querying.feature
+++ b/tests/features/search/querying.feature
@@ -14,6 +14,7 @@ Feature: Search querying
     And I enter "no results for GIBBERISHABCDEFGHIJKLMONP" in the `search box`
     And I click the `search button`
     Then I don't see a `search result`
+    And I don't see a `warning notice`
 
   Scenario: Search with invalid query syntax
 

--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -27,11 +27,17 @@ defineStep(/^I (?:browse|open|visit).*? `(.*?)`$/, pageName => {
   }
 });
 
-defineStep(/^I (?:find|identify|see|spot).*? (`.*`)$/, selectorChain =>
+defineStep(/^I (?:find|identify|see|spot)(?! a link to).*? (`.*`)$/, (selectorChain, _empty) =>
   client.expect.element(nestedSelector(selectorChain)).to.be.visible);
+
+defineStep(/^I wait for.*? (`.*`)$/, selectorChain =>
+  client.waitForElementVisible(nestedSelector(selectorChain)));
 
 defineStep(/^I (?:find|identify|see|spot).*? (`.*`) with the text "(.*)"$/, (selectorChain, value) =>
   client.expect.element(nestedSelector(selectorChain)).text.to.contain(value));
+
+defineStep(/^I (?:find|identify|see|spot) a link to "(.*)" in .*?(`.*`)$/, (value, selectorChain) =>
+  client.expect.element(nestedSelector(selectorChain) + ` a[href="${value}"]`).to.be.visible);
 
 defineStep(/^I (?:can|don)'t (?:find|identify|see|spot).*? (`.*`).*?$/, selectorChain =>
   client.expect.element(nestedSelector(selectorChain)).to.not.be.present);

--- a/tests/unit/components/generic/InfoMessage.spec.js
+++ b/tests/unit/components/generic/InfoMessage.spec.js
@@ -1,0 +1,20 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import BootstrapVue from 'bootstrap-vue';
+import InfoMessage from '../../../../components/generic/InfoMessage.vue';
+
+const localVue = createLocalVue();
+localVue.use(BootstrapVue);
+
+const factory = () => shallowMount(InfoMessage, {
+  localVue
+});
+
+describe('components/generic/InfoMessage', () => {
+  it('show an info message', () => {
+    const wrapper = factory();
+    wrapper.setProps({ message: 'Some information to display' });
+
+    const message =  wrapper.find('[data-qa="info notice"]');
+    message.text().should.contain('Some information to display');
+  });
+});

--- a/tests/unit/plugins/europeana/search.spec.js
+++ b/tests/unit/plugins/europeana/search.spec.js
@@ -174,6 +174,24 @@ describe('plugins/europeana/search', () => {
           response.totalResults.should.eq(apiResponse.totalResults);
         });
 
+        it('returns lastAvailablePage as false', async () => {
+          const response = await searchResponse();
+
+          response.lastAvailablePage.should.eq(false);
+        });
+
+        describe('when page is at the API limit', () => {
+          function searchResponse() {
+            return search({ query: 'painting', wskey: apiKey, page: 42 });
+          }
+
+          it('returns lastAvailablePage as true', async () => {
+            const response = await searchResponse();
+
+            response.lastAvailablePage.should.eq(true);
+          });
+        });
+
         describe('each member of .results', () => {
           it('includes Europeana ID in .europeanaId', async () => {
             const response = await searchResponse();


### PR DESCRIPTION
* Add notice to last available page.*
* Set qfParams from url
* Hide notice/totals when there are no results/errors.
* Features and specs.

*The info notice for now has been added as its own component since it uses different data-qa and text decoration than the error notice. Perhaps these can be rolled into one component that takes more arguments(/configurations) along with the message notice. However for now that seems more complex than individual components.

Fixed a unit test warning by defaulting the pagination total results to be at least 1 as the bootstrap component expects a positive integer.