### PR TITLE
Reusability pseudo facet

### DIFF
--- a/components/search/SearchFacet.vue
+++ b/components/search/SearchFacet.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
     <b-card
+      :data-facet-name="name"
       :header="name | searchFacetHeader"
       class="mb-3"
       data-qa="search facet"
-      :data-facet-name="name"
     >
       <b-form-checkbox-group
         v-model="selected"

--- a/components/search/SearchFacet.vue
+++ b/components/search/SearchFacet.vue
@@ -4,6 +4,7 @@
       :header="name | searchFacetHeader"
       class="mb-3"
       data-qa="search facet"
+      :data-facet-name="name"
     >
       <b-form-checkbox-group
         v-model="selected"

--- a/components/search/SearchFacet.vue
+++ b/components/search/SearchFacet.vue
@@ -12,11 +12,11 @@
         plain
       >
         <b-form-checkbox
-          v-for="(fieldCount, fieldValue) in fields"
-          :key="fieldValue"
-          :value="fieldValue"
+          v-for="field in fields"
+          :key="field.label"
+          :value="field.label"
         >
-          {{ fieldValue }} ({{ fieldCount | localise }})
+          {{ field.label }} ({{ field.count | localise }})
         </b-form-checkbox>
       </b-form-checkbox-group>
     </b-card>
@@ -31,8 +31,8 @@
         default: ''
       },
       fields: {
-        type: Object,
-        default: () => {}
+        type: Array,
+        default: () => []
       },
       selectedFields: {
         type: Array,

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -164,8 +164,8 @@
       },
       /**
        * Sort the facets from the API response
-       * Facets are returned in the order their name is given in the `order` argument,
-       * followed by all others in the order the API returned them.
+       * Facets are returned in the hard-coded preferred order, followed by all
+       * others in the order the API returned them.
        * @return {Object[]} ordered facets
        * TODO: does this belong in its own component?
        */

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -169,6 +169,7 @@
        * Facets are returned in the order their name is given in the `order` argument,
        * followed by all others in the order the API returned them.
        * @return {Object[]} ordered facets
+       * TODO: does this belong in its own component?
        */
       orderedFacets: function () {
         const order = ['TYPE', 'REUSABILITY'];

--- a/plugins/europeana/search.js
+++ b/plugins/europeana/search.js
@@ -87,63 +87,6 @@ function resultsFromApiResponse(response) {
 }
 
 /**
- * A search response facet.
- *
- * The object is keyed by field label with item count as value.
- *
- * For example:
- * ```
- * {
- *   IMAGE: 33371202,
- *   TEXT: 22845674,
- *   VIDEO: 1137194,
- *   SOUND: 699155,
- *   '3D': 28460
- * }
- * ```
- * @typedef {Object.<string, number>} Facet
- */
-
-/**
- * A set of search response facets.
- *
- * The object is keyed by the facet name.
- *
- * For example:
- * ```
- * {
- *   TYPE: {
- *     IMAGE: 10
- *   }
- * }
- * ```
- * @typedef {Object.<string, Facet>} FacetSet
- */
-
-/**
- * Extract facets from API response
- * @param  {Object} response API response
- * @return {FacetSet} facets
- */
-function facetsFromApiResponse(response) {
-  if (!response.data.facets) {
-    return null;
-  }
-  const responseFacets = response.data.facets;
-
-  let facets = {};
-  for (let responseFacet of responseFacets) {
-    let facetFields = {};
-    for (let responseFacetField of responseFacet.fields) {
-      facetFields[responseFacetField.label] = responseFacetField.count;
-    }
-    facets[responseFacet.name] = facetFields;
-  }
-
-  return facets;
-}
-
-/**
  * Page to request from API based on URL query parameter
  * If parameter is not present, returns default of page 1.
  * If parameter is present, and represents a positive integer, return it
@@ -180,14 +123,14 @@ export function pageFromQuery(queryPage) {
  */
 
 /**
- * Extract selected facets from URL `qf` value(s)
- * @param {(string|Array)} queryQf one or many `qf` values
+ * Extract selected facets from URL `qf` and `reusability` value(s)
+ * @param {Object} query URL query parameters
  * @return {SelectedFacetSet} selected facets
  */
-export function selectedFacetsFromQueryQf(queryQf) {
+export function selectedFacetsFromQuery(query) {
   let selectedFacets = {};
-  if (queryQf) {
-    for (const qf of [queryQf].flat()) {
+  if (query.qf) {
+    for (const qf of [query.qf].flat()) {
       const qfParts = qf.split(':');
       const facetName = qfParts[0];
       const facetValue = qfParts[1];
@@ -196,6 +139,9 @@ export function selectedFacetsFromQueryQf(queryQf) {
       }
       selectedFacets[facetName].push(facetValue);
     }
+  }
+  if (query.reusability) {
+    selectedFacets['REUSABILITY'] = query.reusability.split(',');
   }
   return selectedFacets;
 }
@@ -222,9 +168,10 @@ function search(params) {
     },
     params: {
       profile: 'minimal,facets',
-      facet: 'TYPE',
+      facet: 'REUSABILITY,TYPE',
       query: params.query == '' ? '*:*' : params.query,
       qf: params.qf,
+      reusability: params.reusability,
       rows: rows,
       start: start,
       wskey: params.wskey
@@ -234,7 +181,7 @@ function search(params) {
       return {
         error: null,
         results: resultsFromApiResponse(response),
-        facets: facetsFromApiResponse(response),
+        facets: response.data.facets || null,
         totalResults: response.data.totalResults
       };
     })

--- a/plugins/europeana/search.js
+++ b/plugins/europeana/search.js
@@ -150,6 +150,8 @@ export function selectedFacetsFromQuery(query) {
  * Search Europeana Record API
  * @param {Object} params parameters for search query
  * @param {number} params.page page of results to retrieve
+ * @param {string} params.reusability reusability filter
+ * @param {(string|string[])} params.qf query filter(s)
  * @param {string} params.query search query
  * @param {string} params.wskey API key
  * @return {{results: Object[], totalResults: number, facets: FacetSet, error: string}} search results for display

--- a/plugins/vue-filters.js
+++ b/plugins/vue-filters.js
@@ -4,9 +4,17 @@
  */
 
 import Vue from 'vue';
-Vue.filter('localise', val => val.toLocaleString('en'));
+Vue.filter('localise', val => {
+  if (typeof val === 'undefined' || val === null) {
+    return val;
+  }
+  return val.toLocaleString('en');
+});
 
 Vue.filter('searchFacetHeader', val => {
-  const headerText = { 'TYPE': 'Type of media' };
+  const headerText = {
+    'REUSABILITY': 'Can I reuse this?',
+    'TYPE': 'Type of media'
+  };
   return headerText[val] || val;
 });

--- a/tests/features/search/faceting.feature
+++ b/tests/features/search/faceting.feature
@@ -14,3 +14,11 @@ Feature: Search faceting
     And I wait 1 second
     Then I should be on `/search?query=&page=1&qf=TYPE%3AIMAGE`
     And I see a `filter badge` with the text "Type of media: IMAGE"
+
+  Scenario: Filtering results by reusability
+
+    When I visit `/search?query=`
+    And I check the "open" checkbox
+    And I wait 1 second
+    Then I should be on `/search?query=&page=1&reusability=open`
+    And I see a `filter badge` with the text "Can I reuse this?: open"

--- a/tests/unit/components/search/SearchFacet.spec.js
+++ b/tests/unit/components/search/SearchFacet.spec.js
@@ -10,10 +10,13 @@ const factory = () => mount(SearchFacet, {
 });
 
 const facetName = 'TYPE';
-const facetFields = { 'TEXT': 123456, 'VIDEO': 567 };
+const facetFields = [
+  { label: 'TEXT', count: 123456 },
+  { label: 'VIDEO', count: 567 }
+];
 
 describe('components/search/SearchFacet', () => {
-  it('has the text `Type of media` in the header', () => {
+  it('has the facet label in the header', () => {
     const wrapper = factory();
     wrapper.setProps({ name: facetName, fields: facetFields });
 
@@ -21,12 +24,20 @@ describe('components/search/SearchFacet', () => {
     facetHeader.text().should.eq('Type of media');
   });
 
-  it('has two checkboxes', () => {
+  it('has a checkbox for each field', () => {
     const wrapper = factory();
     wrapper.setProps({ name: facetName, fields: facetFields });
 
     const facets =  wrapper.find('[data-qa="search facet"]').findAll('input[type="checkbox"]');
-    facets.length.should.eq(2);
+    facets.length.should.eq(facetFields.length);
+  });
+
+  it('keeps facet name in `data-facet-name`', () => {
+    const wrapper = factory();
+    wrapper.setProps({ name: facetName, fields: facetFields });
+
+    const facetContainer =  wrapper.find('[data-qa="search facet"]');
+    facetContainer.attributes('data-facet-name').should.eq(facetName);
   });
 
   it('emits `changed` event when selected', () => {

--- a/tests/unit/plugins/europeana/search.spec.js
+++ b/tests/unit/plugins/europeana/search.spec.js
@@ -328,9 +328,17 @@ describe('plugins/europeana/search', () => {
     describe('with multiple query qf values', () => {
       it('returns them in arrays on properties named for each facet', () => {
         const query = { qf: ['TYPE:IMAGE', 'TYPE:VIDEO', 'REUSABILITY:open'] };
-        const expectedReturn = { 'TYPE': ['IMAGE', 'VIDEO'], 'REUSABILITY': ['open'] };
+        const expected = { 'TYPE': ['IMAGE', 'VIDEO'], 'REUSABILITY': ['open'] };
 
-        selectedFacetsFromQuery(query).should.deep.eql(expectedReturn);
+        selectedFacetsFromQuery(query).should.deep.eql(expected);
+      });
+    });
+
+    describe('with reusability values', () => {
+      it('returns them in an array on REUSABILITY property', () => {
+        const query = { reusability: 'open,restricted' };
+        const expected = { 'REUSABILITY': ['open', 'restricted'] };
+        selectedFacetsFromQuery(query).should.deep.eql(expected);
       });
     });
   });


### PR DESCRIPTION
* Support faceting by reusability with `reusability` URL parameter.
* Stop modifying the API's facets response and just pass to the templates as-is.
* Set the order in which facets should be displayed.
* DRY up the logic for generating new search routes