### PR TITLE
Watch for search query changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,31 +42,38 @@ To run a single file: `npm run test:unit -g tests/unit/[REST_OF_FILE_PATH]`
 
 `npm run test:e2e` and `npm run test:e2e:ci` just run everything.
 
-
 If you've manually started the test server with: `npm run build:test && npm run start:test`, then you can for example:
 
 Run only the header.feature file using path.
 
-```npm run test:chrome:headless tests/features/header.feature```
+```shell
+npm run test:chrome:headless tests/features/header.feature
+```
 
 
-Run only the "header" feature using it's name.
+Run only the "header" feature test using its name.
 
-```npm run test:chrome:headless -- -p all --name header```
+```shell
+npm run test:chrome:headless -- -p all --name header
+```
 
 
 Run only the "header" feature in the header file.
 
-```npm run test:chrome:headless tests/features/header.feature -- --name header```
-
+```shell
+npm run test:chrome:headless tests/features/header.feature -- --name header
+```
 
 Run everything with your driver of choice.
 
-```npm run test:chrome:headless -- -p all```
-
+```
+npm run test:chrome:headless -- -p all
+```
 
 `test:chrome:headless` can be substituited for the other avialable driver commands `test:gecko` and `test:chrome`.
 
+Be aware however that with `geckodriver` some tests are known to fail as it is not yet feature complete.
+It is therefore at present of limited use.
 
 
 ## License

--- a/components/PageHeader.vue
+++ b/components/PageHeader.vue
@@ -69,7 +69,7 @@
     },
     data () {
       return {
-        query: this.searchQuery,
+        query: this.searchQuery ? this.searchQuery : '',
         isLoading: false
       };
     },
@@ -82,7 +82,7 @@
       searchQuery: {
         immediate: true,
         handler(val) {
-          this.query = val;
+          this.query = val ? val : '';
         }
       }
     },

--- a/components/PageHeader.vue
+++ b/components/PageHeader.vue
@@ -69,7 +69,7 @@
     },
     data () {
       return {
-        query: this.searchQuery ? this.searchQuery : '',
+        query: this.searchQuery || '',
         isLoading: false
       };
     },
@@ -82,7 +82,7 @@
       searchQuery: {
         immediate: true,
         handler(val) {
-          this.query = val ? val : '';
+          this.query = val || '';
         }
       }
     },
@@ -90,8 +90,7 @@
       submitSearchForm () {
         this.$router.push(this.localePath({ name: 'search', query: { query: this.query } }));
       }
-    },
-    watchQuery: ['query']
+    }
   };
 </script>
 

--- a/components/PageHeader.vue
+++ b/components/PageHeader.vue
@@ -61,11 +61,15 @@
       langSelectEnabled: {
         type: Boolean,
         default: false
+      },
+      searchQuery: {
+        type: String,
+        default: ''
       }
     },
     data () {
       return {
-        query: this.getQueryFromParam(),
+        query: this.searchQuery,
         isLoading: false
       };
     },
@@ -74,12 +78,17 @@
         return this.$i18n.locales.filter(i => i.code !== this.$i18n.locale);
       }
     },
+    watch: {
+      searchQuery: {
+        immediate: true,
+        handler(val) {
+          this.query = val;
+        }
+      }
+    },
     methods: {
       submitSearchForm () {
-        this.$router.push(this.localePath({ name: 'search', query: { query: this.query ? this.query : '' } }));
-      },
-      getQueryFromParam () {
-        return this.$route.query ? this.$route.query.query : null;
+        this.$router.push(this.localePath({ name: 'search', query: { query: this.query } }));
       }
     },
     watchQuery: ['query']

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,6 +9,7 @@
     </a>
     <PageHeader
       :lang-select-enabled="langSelectEnabled"
+      :search-query="searchQuery"
     />
     <nuxt
       id="main"
@@ -26,11 +27,29 @@
       PageHeader,
       PageFooter
     },
+    data () {
+      return {
+        searchQuery: this.getQueryFromParam()
+      };
+    },
     computed: {
       langSelectEnabled() {
         return process.env.ENABLE_LANG_SELECT === 'true';
       }
-    }
+    },
+    created () {
+      this.$root.$on('leaveSearchPage', () => {
+        this.searchQuery = '';
+      });
+      this.$root.$on('updateSearchQuery', (val) => {
+        this.searchQuery = val;
+      });
+    },
+    methods: {
+      getQueryFromParam () {
+        return this.$route.query ? this.$route.query.query : '';
+      }
+    },
+    watchQuery: ['query']
   };
-
 </script>

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:chrome": "cross-env browser=chrome cucumber-js",
     "test:chrome:headless": "cross-env browser=chromeHeadless cucumber-js",
     "test:gecko": "cross-env browser=gecko cucumber-js --no-strict",
-    "test:e2e": "concurrently 'npm run build:test && npm run start:test' 'npm run test:chrome -- -p all && npm run test:gecko -- -p all' --success first --kill-others",
+    "test:e2e": "concurrently 'npm run build:test && npm run start:test' 'npm run test:chrome -- -p all' --success first --kill-others",
     "test:e2e:ci": "concurrently 'npm run build:test && npm run start:test' 'npm run test:chrome:headless -- -p all' --success first --kill-others"
   },
   "dependencies": {

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -179,6 +179,14 @@
         return ordered.concat(unordered);
       }
     },
+    watch: {
+      query: {
+        immediate: true,
+        handler(val) {
+          this.$root.$emit('updateSearchQuery', val);
+        }
+      }
+    },
     asyncData ({ env, query, res, redirect, app }) {
       const currentPage = pageFromQuery(query.page);
       if (currentPage === null) {
@@ -287,6 +295,10 @@
       return {
         title: 'Search'
       };
+    },
+    beforeRouteLeave (to, from, next) {
+      this.$root.$emit('leaveSearchPage');
+      next();
     },
     watchQuery: ['page', 'qf', 'query', 'reusability']
   };

--- a/tests/features/search/querying.feature
+++ b/tests/features/search/querying.feature
@@ -5,7 +5,8 @@ Feature: Search querying
     When I visit a `search page`
     And I enter "paris" in the `search box`
     And I click the `search button`
-    Then I see a `search result`
+    Then I see "paris" in the `search box`
+    And I see a `search result`
     And I see the `total results`
     And I am on an accessible page
 
@@ -32,3 +33,4 @@ Feature: Search querying
     And I click the `search button`
     And I click a `search result`
     Then I see a `record page`
+    And I don't see "paris" in the `search box`

--- a/tests/features/support/step-definitions.js
+++ b/tests/features/support/step-definitions.js
@@ -29,7 +29,7 @@ defineStep('I find/identify/see/spot (a/an/the)( ){target} with the text {string
 defineStep('I can\'t/don\'t find/identify/see/spot (a/an/the)( ){target}', (qa) =>
   i.doNotSeeATarget(qa));
 
-defineStep('I can\'t/don\'t  find/identify/see/spot (a/an/the)( ){target} in/on the {target}', (qa, parentQa) =>
+defineStep('I can\'t/don\'t find/identify/see/spot (a/an/the)( ){target} in/on the {target}', (qa, parentQa) =>
   i.doNotSeeATarget([qa, parentQa]));
 
 defineStep('I wait/pause {int} second(s)', (seconds) =>
@@ -40,6 +40,12 @@ defineStep('I press/hit/type the {word} key', (key) =>
 
 defineStep('I enter/fill/input/supply/type {string} in/on (the ){target}', (text, qa) =>
   i.enterTextInTarget(text, qa));
+
+defineStep('I find/identify/see/spot {string} in/on (the ){target}', (text, qa) =>
+  i.seeTextInTarget(text, qa));
+
+defineStep('I can\'t/don\'t find/identify/see/spot {string} in/on (the ){target}', (text, qa) =>
+  i.doNotSeeTextInTarget(text, qa));
 
 defineStep('I activate/click (the/a/an)( ){target}', (qa) =>
   i.clickOnTheTarget(qa));
@@ -76,4 +82,3 @@ defineStep('I should have/see/see/spot a meta label {target} with the value {str
 
 defineStep('I am on an accessible page',() =>
   i.checkPageAccesibility());
-

--- a/tests/features/support/step-runners.js
+++ b/tests/features/support/step-runners.js
@@ -118,6 +118,19 @@ module.exports = {
   seeATargetWithText: async function (qaElementNames, text) {
     await client.expect.element(qaSelector(qaElementNames)).text.to.contain(text);
   },
+  seeTextInTarget: async function (text, qaElementName) {
+    const selector = qaSelector(qaElementName);
+    await client.getValue(selector, async (result) => {
+      await client.expect(result.value).to.eq(text);
+    });
+  },
+  doNotSeeTextInTarget: async function (text, qaElementName) {
+    const selector = qaSelector(qaElementName);
+    await client.expect.element(selector).to.be.visible;
+    await client.getValue(selector, async (result) => {
+      await client.expect(result.value).to.not.eq(text);
+    });
+  },
   shouldBeOn: async function (pageName) {
     // TODO: update if a less verbose syntax becomes available.
     // See https://github.com/nightwatchjs/nightwatch/issues/861

--- a/tests/features/support/step-runners.js
+++ b/tests/features/support/step-runners.js
@@ -56,12 +56,13 @@ module.exports = {
   },
   clickOnTheTarget: async function (qaElementNames) {
     const selector = qaSelector(qaElementNames);
-    await client.expect.element(selector).to.be.visible;
+    await client.waitForElementVisible(selector);
     await client.click(selector);
   },
   clickOnLink: async function (href) {
-    await client.expect.element(`a[href="${href}"]`).to.be.visible;
-    await client.click(`a[href="${href}"]`);
+    const selector = `a[href="${href}"]`;
+    await client.waitForElementVisible(selector);
+    await client.click(selector);
   },
   countTarget: async (count, qaElementNames) => {
     await client.elements('css selector', qaSelector(qaElementNames), async(result) => {
@@ -103,7 +104,7 @@ module.exports = {
   },
   enterTextInTarget: async function (text, qaElementName) {
     const selector = qaSelector(qaElementName);
-    await client.expect.element(selector).to.be.visible;
+    await client.waitForElementVisible(selector);
     await client.setValue(selector, text);
   },
   openAPage: async function (pageName) {
@@ -126,7 +127,7 @@ module.exports = {
   },
   doNotSeeTextInTarget: async function (text, qaElementName) {
     const selector = qaSelector(qaElementName);
-    await client.expect.element(selector).to.be.visible;
+    await client.waitForElementVisible(selector);
     await client.getValue(selector, async (result) => {
       await client.expect(result.value).to.not.eq(text);
     });

--- a/tests/features/support/step-runners.js
+++ b/tests/features/support/step-runners.js
@@ -73,15 +73,7 @@ module.exports = {
     if (key.length > 1) {
       key = client.Keys[key];
     }
-    let runtimeBrowser = client.capabilities.browserName.toUpperCase();
-
-    if (runtimeBrowser === 'CHROME') {
-      await client.keys(key);
-    } else if (runtimeBrowser === 'FIREFOX') {
-      // This doesn't work with the gecko driver
-      // await client.keys(key);
-      return 'pending';
-    }
+    await client.keys(key);
   },
   matchMetaLabelAndValue: async (label, value) => {
     await client.elements('xpath', '//strong[contains(text(),"' + label + '")]/parent::div/parent::div//span[contains(text(),"' + value + '")]', async(result) => {


### PR DESCRIPTION
When leaving the search results page, remove the user's search query from the form input in the header, but ensure it is restored if they return using their browser's back button.

* Moves reading of the query up to the layout level which passes it down to the header component
* Uses a Vue "navigation guard" to observe when the search page is left for another, per https://router.vuejs.org/guide/advanced/navigation-guards.html#in-component-guards
* Uses an "event hub" to emit global events, per https://github.com/nuxt/nuxt.js/issues/849#issuecomment-307016399