### PR TITLE
Persist search results `view` with params and storage

### DIFF
--- a/components/search/SearchResultsGrid.vue
+++ b/components/search/SearchResultsGrid.vue
@@ -2,6 +2,7 @@
   <b-card-group
     class="card-deck-3-cols card-deck-search"
     deck
+    data-qa="search results grid"
   >
     <ContentCard
       v-for="result in results"

--- a/components/search/SearchResultsList.vue
+++ b/components/search/SearchResultsList.vue
@@ -1,5 +1,7 @@
 <template>
-  <b-list-group>
+  <b-list-group
+    data-qa="search results list"
+  >
     <b-list-group-item
       v-for="result in results"
       :key="result.europeanaId"

--- a/components/search/ViewToggles.vue
+++ b/components/search/ViewToggles.vue
@@ -9,13 +9,12 @@
       :active="activeView == view"
       :data-qa="`search ${view} view toggle`"
       class="pl-3"
-      @click="selectView"
+      @click="selectView(view)"
     >
       <img
         :src="iconSrc(view)"
         :alt="$t(`searchViews.${view}`)"
         :title="$t(`searchViews.${view}`)"
-        :data-view="view"
       >
     </b-nav-item>
   </b-nav>
@@ -45,9 +44,9 @@
           name: 'search', query: { ...this.$route.query, ...{ view: view } }
         });
       },
-      selectView: function (event) {
-        if (event.target.getAttribute('data-view') !== this.activeView) {
-          this.activeView = event.target.getAttribute('data-view');
+      selectView: function (view) {
+        if (view !== this.activeView) {
+          this.activeView = view;
           this.$emit('changed', this.activeView);
         }
       }

--- a/components/search/ViewToggles.vue
+++ b/components/search/ViewToggles.vue
@@ -46,8 +46,10 @@
         });
       },
       selectView: function (event) {
-        this.activeView = event.target.getAttribute('data-view');
-        this.$emit('changed', this.activeView);
+        if (event.target.getAttribute('data-view') !== this.activeView) {
+          this.activeView = event.target.getAttribute('data-view');
+          this.$emit('changed', this.activeView);
+        }
       }
     }
   };
@@ -91,6 +93,14 @@
     &:hover img,
     &.active img {
       filter: invert(0);
+    }
+
+    &.active {
+      cursor: default;
+      &:before {
+        opacity: 0;
+        transform: scale(0);
+      }
     }
   }
 </style>

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -156,7 +156,7 @@
         reusability: '',
         selectedFacets: {},
         totalResults: null,
-        view: 'grid'
+        view: this.selectedView()
       };
     },
     computed: {
@@ -301,7 +301,21 @@
         this.rerouteSearch({ qf: this.qfForSelectedFacets, reusability: this.reusability, page: '1' });
       },
       selectView (view) {
+        if (process.browser) {
+          sessionStorage.view = view;
+          localStorage.view = view;
+        }
         this.view = view;
+        this.view = view;
+      },
+      selectedView: function () {
+        if (process.browser) {
+          if (this.$route.query.view) {
+            sessionStorage.view = this.$route.query.view;
+          }
+          return sessionStorage.view || localStorage.view || 'grid';
+        }
+        return 'grid';
       }
     },
     head () {

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -89,6 +89,10 @@
               >
                 {{ $t('noMoreResults') }}
               </p>
+              <SearchResultsList
+                v-else-if="view == 'list'"
+                :results="results"
+              />
               <SearchResultsGrid
                 v-else
                 :results="results"
@@ -121,6 +125,7 @@
   import InfoMessage from '../../components/generic/InfoMessage';
   import SearchFacet from '../../components/search/SearchFacet';
   import SearchResultsGrid from '../../components/search/SearchResultsGrid';
+  import SearchResultsList from '../../components/search/SearchResultsList';
   import SearchSelectedFacets from '../../components/search/SearchSelectedFacets';
   import PaginationNav from '../../components/generic/PaginationNav';
   import ViewToggles from '../../components/search/ViewToggles';
@@ -132,6 +137,7 @@
       InfoMessage,
       SearchFacet,
       SearchResultsGrid,
+      SearchResultsList,
       SearchSelectedFacets,
       PaginationNav,
       ViewToggles

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -298,20 +298,19 @@
       },
       selectView (view) {
         if (process.browser) {
-          sessionStorage.view = view;
-          localStorage.view = view;
+          sessionStorage.searchResultsView = view;
+          localStorage.searchResultsView = view;
         }
-        this.view = view;
         this.view = view;
       },
       selectedView: function () {
         if (process.browser) {
           if (this.$route.query.view) {
-            sessionStorage.view = this.$route.query.view;
+            sessionStorage.searchResultsView = this.$route.query.view;
           }
-          return sessionStorage.view || localStorage.view || 'grid';
+          return sessionStorage.searchResultsView || localStorage.searchResultsView || 'grid';
         }
-        return 'grid';
+        return this.$route.query.view || 'grid';
       }
     },
     head () {

--- a/tests/features/search/view.feature
+++ b/tests/features/search/view.feature
@@ -1,0 +1,35 @@
+Feature: View styles (List and Grid)
+  In order to gain a better overview of
+  different types of europeana records,
+  as a user I want to be able to switch between
+  a list and grid view style when on
+  search results pages.
+
+  Scenario: Defaulting to grid view
+    When I visit the `search page`
+    And I click the `search button`
+    Then I see a `search results grid`
+
+  Scenario: Defaulting to grid view after paginating
+    When I visit the `search page`
+    And I click the `search button`
+    And I click the "/search?page=2&query=&view=grid" link
+    Then I see a `search results grid`
+
+  Scenario: Switching to the list view
+    When I visit the `search page`
+    And I click the `search button`
+    And I click the `search list view toggle`
+    Then I see a `search results list`
+
+  Scenario: Switching to the grid view
+    When I open `/search?query=&view=list`
+    And I click the `search grid view toggle`
+    Then I see a `search results grid`
+
+  Scenario: Switching to the list view and paginating
+    When I visit the `search page`
+    And I click the `search button`
+    And I click the `search list view toggle`
+    And I click the "/search?page=2&query=&view=list" link
+    Then I see a `search results list`


### PR DESCRIPTION
Use params and local/session storage to track views.

This PR also integrates all components and adds:
* Feature tests
* Styling for distinguishing active/inactive view toggles
* Stop emitting events when toggle doesn't change the value