### PR TITLE
Stop CSS escaping background image URLs

### DIFF
--- a/components/generic/ContentCard.vue
+++ b/components/generic/ContentCard.vue
@@ -11,7 +11,7 @@
       <div
         v-if="imageUrl"
         :aria-label="title"
-        :style="{'background-image': 'url(' + backgroundImageUrl + ')'}"
+        :style="cardImageStyle"
         class="card-img"
       />
       <b-card-body>
@@ -30,8 +30,6 @@
 </template>
 
 <script>
-  require('css.escape');
-
   export default {
     props: {
       title: {
@@ -52,8 +50,10 @@
       }
     },
     computed: {
-      backgroundImageUrl() {
-        return CSS.escape(this.imageUrl);
+      cardImageStyle() {
+        return {
+          backgroundImage: `url("${this.imageUrl}")`
+        };
       }
     }
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7055,11 +7055,6 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
     },
-    "css.escape": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
-    },
     "cssdb": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-4.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "bootstrap-vue": "^2.0.0-rc.24",
     "contentful": "^7.4.1",
     "cross-env": "^5.2.0",
-    "css.escape": "^1.5.1",
     "elastic-apm-node": "^2.6.0",
     "express": "^4.16.4",
     "express-ipfilter": "^1.0.1",

--- a/tests/unit/components/generic/ContentCard.spec.js
+++ b/tests/unit/components/generic/ContentCard.spec.js
@@ -45,6 +45,6 @@ describe('components/generic/ContentCard', () => {
     wrapper.setProps({ imageUrl: 'https://example.org' });
 
     const card =  wrapper.find('[data-qa="content card"] .card-img');
-    card.attributes('style').should.contain('https\\:\\/\\/example\\.org');
+    card.attributes('style').should.contain('https://example.org');
   });
 });


### PR DESCRIPTION
As it results in malformed URLs SSR, due to Vue's escaping backslashes in dynamic style attributes.