### PR TITLE
Search Redirect

### DIFF
--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -221,7 +221,8 @@
       }
 
       if (typeof query.query === 'undefined') {
-        return;
+        query.query = '';
+        return redirect(app.localePath({ name: 'search', query }));
       }
 
       return search({

--- a/tests/features/common/language-selector.feature
+++ b/tests/features/common/language-selector.feature
@@ -2,10 +2,10 @@ Feature: Select language
 
   Scenario: Change language
 
-    When I visit `/de/search`
+    When I visit `/de/search?query=`
     And I click the `language selector`
     And I see a `Svenska language option` in the `language selector`
     And I click the `Svenska language option`
     And I wait 2 seconds
-    Then I should be on `/sv/search`
+    Then I should be on `/sv/search?query=`
     And I see the text "Vad letar du efter?" in the `search box` placeholder

--- a/tests/features/search/faceting.feature
+++ b/tests/features/search/faceting.feature
@@ -9,7 +9,7 @@ Feature: Search faceting
 
   Scenario: Filtering results by theme
 
-    When I visit `/search?query=`
+    When I visit the `search page`
     And I check the "art" radio
     And I wait 3 seconds
     Then I should be on `/search?page=1&query=&theme=art&view=grid`
@@ -17,7 +17,7 @@ Feature: Search faceting
 
   Scenario: Filtering results by types
 
-    When I visit `/search?query=`
+    When I visit the `search page`
     And I check the "IMAGE" checkbox
     And I wait 2 seconds
     Then I should be on `/search?page=1&qf=TYPE%3A%22IMAGE%22&query=&view=grid`
@@ -26,7 +26,7 @@ Feature: Search faceting
 
   Scenario: Filtering results by reusability
 
-    When I visit `/search?query=`
+    When I visit the `search page`
     And I check the "open" checkbox
     And I wait 2 seconds
     Then I should be on `/search?page=1&query=&reusability=open&view=grid`
@@ -34,7 +34,7 @@ Feature: Search faceting
 
   Scenario: Filtering results by country
 
-    When I visit `/search?query=`
+    When I visit the `search page`
     And I check the "Belgium" checkbox
     And I wait 2 seconds
     Then I should be on `/search?page=1&qf=COUNTRY%3A%22Belgium%22&query=&view=grid`
@@ -42,7 +42,7 @@ Feature: Search faceting
 
   Scenario: Filtering results by two countries
 
-    When I visit `/search?query=`
+    When I visit the `search page`
     And I check the "Belgium" checkbox
     And I check the "Germany" checkbox
     And I wait 2 seconds
@@ -51,7 +51,7 @@ Feature: Search faceting
 
   Scenario: Filtering using a combination of facet fields
 
-    When I visit the `/search?query=`
+    When I visit the `search page`
     And I check the "Belgium" checkbox
     And I check the "IMAGE" checkbox
     And I check the "open" checkbox
@@ -76,7 +76,7 @@ Feature: Search faceting
 
   Scenario: Filtering results by country and have a corresponding record page
 
-    When I visit `/search?query=`
+    When I visit the `search page`
     And I check the "Belgium" checkbox
     And I wait 2 seconds
     And I click a `search result`
@@ -86,7 +86,7 @@ Feature: Search faceting
 
   Scenario: Filtering results by two countries and have a corresponding record page
 
-    When I visit `/search?query=`
+    When I visit the `search page`
     And I check the "Belgium" checkbox
     And I check the "Germany" checkbox
     And I wait 2 seconds
@@ -97,7 +97,7 @@ Feature: Search faceting
 
   Scenario: Preserve filtering when perfoming a new search
 
-      When I visit `/search?query=`
+      When I visit the `search page`
       And I check the "France" checkbox
       And I wait 2 seconds
       And I enter "paris" in the `search box`

--- a/tests/features/search/querying.feature
+++ b/tests/features/search/querying.feature
@@ -1,4 +1,8 @@
 Feature: Search querying
+  
+  Scenario: Redirect when no query parameter is present
+    When I visit `/search`
+    Then I should be on `/search?query=`
 
   Scenario: Search existing Europeana content
 

--- a/tests/features/support/step-runners.js
+++ b/tests/features/support/step-runners.js
@@ -9,7 +9,7 @@ const { url } = require('../config/nightwatch.conf.js').test_settings.default.gl
 
 const pages = {
   'home page': `${url}/`,
-  'search page': `${url}/search`,
+  'search page': `${url}/search?query=`,
   'record page': `${url}/record${europeanaId()}`,
   'first page of results': `${url}/search?query=&page=1`,
   'entity page': `${url}/entity/person/200-friedrich-nietzsche`


### PR DESCRIPTION
- When no query parameter is present in the url, redirect /search to /search?query=