### PR TITLE
Remove node_modules in build stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,7 @@ pipeline {
       }
       steps {
         configFileProvider([configFile(fileId: "portaljs.${env.CF_SPACE}.env", targetLocation: '.env')]) {
+          sh 'rm -r node_modules'
           sh 'npm install'
           sh 'npm run build'
         }


### PR DESCRIPTION
To ensure binaries are rebuilt on node version updates