### PR TITLE
Redirect to SSL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,10 @@ GOOGLE_TAG_MANAGER_ID="GTM-XXXXXXX"
 # Redirect all record page requests to this URL path
 RECORD_PAGE_REDIRECT_PATH=/record-page-under-construction
 
+# If disabled, no redirection will occur from http:// requests to https://
+# equivalents. Enabled by default.
+DISABLE_REDIRECT_SSL=1
+
 # If enabled, the content tier toggle will be displayed on the main search
 # results page. Disabled by default.
 ENABLE_CONTENT_TIER_TOGGLE=1

--- a/package-lock.json
+++ b/package-lock.json
@@ -18858,6 +18858,14 @@
         }
       }
     },
+    "redirect-ssl": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/redirect-ssl/-/redirect-ssl-1.4.1.tgz",
+      "integrity": "sha512-8Lg6swHUDPydPKRTV2faJMF2foKw8oUFE7cWoieRpoU57ZjM1cdFVp3YcBar1tM5L6GD9KMDNu6uc0qi/3zSHQ==",
+      "requires": {
+        "is-https": "^1.0.0"
+      }
+    },
     "refractor": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "nuxt-i18n": "^6.1.3",
     "oembed-parser": "^1.3.2",
     "qs": "^6.6.0",
+    "redirect-ssl": "^1.4.1",
     "vcap_services": "^0.7.0",
     "vue": "^2.6.10",
     "vue-markdown": "^2.2.4",

--- a/server/index.js
+++ b/server/index.js
@@ -89,6 +89,11 @@ async function start() {
 
       app.use(httpAuth.connect(digest));
     }
+
+    if (!process.env.DISABLE_REDIRECT_SSL) {
+      const redirectSSL = require('redirect-ssl');
+      app.use(redirectSSL.create({ redirect: true }));
+    }
   }
 
   // Give nuxt middleware to express


### PR DESCRIPTION
Enabled by default on all environments.

To disable, set `DISABLE_REDIRECT_SSL=1` in your env.